### PR TITLE
Add workflow engine stub

### DIFF
--- a/chat_orchestrator_service/routes/apiKeyRoutes.js
+++ b/chat_orchestrator_service/routes/apiKeyRoutes.js
@@ -1,0 +1,27 @@
+const express = require('express');
+const router = express.Router();
+const configStore = require('../utils/configStore');
+
+// Get all stored API keys
+router.get('/', async (req, res) => {
+  res.json({ success: true, keys: configStore.getApiKeys() });
+});
+
+// Store a new API key
+router.post('/', async (req, res) => {
+  const key = {
+    id: Date.now().toString(),
+    value: req.body?.value || '',
+    provider: req.body?.provider || 'unknown'
+  };
+  configStore.addApiKey(key);
+  res.status(201).json({ success: true, key });
+});
+
+// Delete an API key by id
+router.delete('/:id', async (req, res) => {
+  configStore.deleteApiKey(req.params.id);
+  res.json({ success: true });
+});
+
+module.exports = router;

--- a/chat_orchestrator_service/routes/configRoutes.js
+++ b/chat_orchestrator_service/routes/configRoutes.js
@@ -1,0 +1,16 @@
+const express = require('express');
+const router = express.Router();
+const configStore = require('../utils/configStore');
+
+// Return current configuration settings
+router.get('/', async (req, res) => {
+  res.json({ success: true, config: configStore.getSettings() });
+});
+
+// Update configuration settings
+router.put('/', async (req, res) => {
+  const updated = configStore.updateSettings(req.body || {});
+  res.json({ success: true, config: updated });
+});
+
+module.exports = router;

--- a/chat_orchestrator_service/routes/workflowRoutes.js
+++ b/chat_orchestrator_service/routes/workflowRoutes.js
@@ -1,0 +1,17 @@
+const express = require('express');
+const router = express.Router();
+
+// Static workflow phase list
+const phases = [
+  { name: 'INFO_COLLECTION', displayName: 'Information Collection' },
+  { name: 'CASE_ANALYSIS', displayName: 'Case Analysis' },
+  { name: 'PRODUCT_RECOMMENDATION', displayName: 'Product Recommendation' },
+  { name: 'SALES_CONVERSION', displayName: 'Sales Conversion' }
+];
+
+// Return available workflow phases
+router.get('/phases', async (req, res) => {
+  res.json({ success: true, phases });
+});
+
+module.exports = router;

--- a/chat_orchestrator_service/utils/configStore.js
+++ b/chat_orchestrator_service/utils/configStore.js
@@ -1,0 +1,57 @@
+const fs = require('fs');
+const path = require('path');
+
+const dataDir = path.join(__dirname, '../data');
+const configFile = path.join(dataDir, 'config.json');
+
+function load() {
+  try {
+    if (fs.existsSync(configFile)) {
+      return JSON.parse(fs.readFileSync(configFile, 'utf8'));
+    }
+  } catch (err) {
+    console.error('Config load error:', err);
+  }
+  return { apiKeys: [], settings: {} };
+}
+
+function save(data) {
+  fs.mkdirSync(dataDir, { recursive: true });
+  fs.writeFileSync(configFile, JSON.stringify(data, null, 2));
+}
+
+function getSettings() {
+  return load().settings;
+}
+
+function updateSettings(updates) {
+  const data = load();
+  data.settings = Object.assign({}, data.settings, updates);
+  save(data);
+  return data.settings;
+}
+
+function getApiKeys() {
+  return load().apiKeys;
+}
+
+function addApiKey(key) {
+  const data = load();
+  data.apiKeys.push(key);
+  save(data);
+  return key;
+}
+
+function deleteApiKey(id) {
+  const data = load();
+  data.apiKeys = data.apiKeys.filter(k => k.id !== id);
+  save(data);
+}
+
+module.exports = {
+  getSettings,
+  updateSettings,
+  getApiKeys,
+  addApiKey,
+  deleteApiKey
+};

--- a/py_consumer/handlers/__init__.py
+++ b/py_consumer/handlers/__init__.py
@@ -1,0 +1,1 @@
+# handlers package

--- a/py_consumer/logic/__init__.py
+++ b/py_consumer/logic/__init__.py
@@ -1,0 +1,1 @@
+# logic package

--- a/py_consumer/logic/prompt_engine.py
+++ b/py_consumer/logic/prompt_engine.py
@@ -1,0 +1,58 @@
+"""Prompt building utilities."""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, Any, List
+
+from utils.database import DatabaseManager
+
+
+class PromptEngine:
+    """Constructs prompts for the AI providers."""
+
+    def __init__(self) -> None:
+        self.initialized = False
+        self.logger = logging.getLogger(__name__)
+        self.db = DatabaseManager()
+
+    async def initialize(self) -> None:
+        if self.initialized:
+            return
+        self.initialized = True
+        self.logger.info("Prompt engine initialized")
+
+    async def build_prompt(
+        self,
+        message: str,
+        context: List[Dict[str, Any]],
+        phase: str,
+        slots: Dict[str, Any],
+        conversation: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Build a chat completion payload for a provider."""
+
+        if not self.initialized:
+            await self.initialize()
+
+        template = await self.db.get_prompt_template(phase)
+        system_prompt = template['template_content'] if template else ''
+
+        messages: List[Dict[str, str]] = []
+        if system_prompt:
+            messages.append({'role': 'system', 'content': system_prompt})
+
+        for msg in context:
+            messages.append({
+                'role': 'user' if msg['sender_type'] == 'user' else 'assistant',
+                'content': msg['content'],
+            })
+
+        messages.append({'role': 'user', 'content': message})
+
+        return {
+            'messages': messages,
+            'phase': phase,
+            'slots': slots,
+            'conversation': conversation,
+        }

--- a/py_consumer/logic/slot_utils.py
+++ b/py_consumer/logic/slot_utils.py
@@ -1,0 +1,37 @@
+import re
+import logging
+from typing import Dict, Any
+
+
+class SlotExtractor:
+    """Simple slot extractor using regex patterns."""
+
+    EMAIL_RE = re.compile(r"[\w.-]+@[\w.-]+")
+    PHONE_RE = re.compile(r"(\+?\d[\d\s-]{7,}\d)")
+    DATE_RE = re.compile(r"\b(\d{4}-\d{1,2}-\d{1,2})\b")
+
+    def __init__(self) -> None:
+        self.initialized = False
+        self.logger = logging.getLogger(__name__)
+
+    async def initialize(self) -> None:
+        self.initialized = True
+        self.logger.info("Slot extractor initialized")
+
+    async def extract_slots(self, message: str, current_phase: str) -> Dict[str, Any]:
+        """Extract basic slots from a user message."""
+        slots: Dict[str, Any] = {}
+
+        email_match = self.EMAIL_RE.search(message)
+        if email_match:
+            slots['email'] = email_match.group(0)
+
+        phone_match = self.PHONE_RE.search(message)
+        if phone_match:
+            slots['phone'] = phone_match.group(0)
+
+        date_match = self.DATE_RE.search(message)
+        if date_match:
+            slots.setdefault('dates', []).append(date_match.group(1))
+
+        return slots

--- a/py_consumer/logic/workflow_engine.py
+++ b/py_consumer/logic/workflow_engine.py
@@ -1,0 +1,61 @@
+"""Simplified workflow engine for Python consumer service.
+This placeholder tracks conversation workflow states so the
+consumer can update progress after each LLM request.
+"""
+
+import logging
+import json
+from pathlib import Path
+from typing import Dict, Any
+
+logger = logging.getLogger(__name__)
+
+
+class WorkflowEngine:
+    """Minimal workflow engine storing per-conversation state."""
+
+    def __init__(self) -> None:
+        # Mapping of conversation_id -> workflow data
+        self._states: Dict[str, Dict[str, Any]] = {}
+        self.initialized = False
+        self._state_file = Path(__file__).parent.parent / 'workflow_state.json'
+
+    async def initialize(self):
+        """Initialize workflow engine."""
+        if self.initialized:
+            return
+        if self._state_file.exists():
+            try:
+                self._states = json.loads(self._state_file.read_text())
+            except Exception:  # pragma: no cover - corrupt file
+                self._states = {}
+        self.initialized = True
+        logger.info("Workflow engine initialized")
+
+    async def update_workflow_state(self, conversation_id: str, response: Dict[str, Any]):
+        """Update stored workflow state for a conversation.
+
+        Parameters
+        ----------
+        conversation_id: str
+            Identifier of the conversation being updated.
+        response: Dict[str, Any]
+            Response returned from the LLM handler containing
+            next_phase and slots information.
+        """
+        if not self.initialized:
+            await self.initialize()
+
+        state = self._states.setdefault(conversation_id, {})
+        state['last_response'] = response
+        state['current_phase'] = response.get('next_phase', state.get('current_phase'))
+        logger.debug("Workflow state updated for %s: %s", conversation_id, state)
+        try:
+            self._state_file.write_text(json.dumps(self._states, indent=2))
+        except Exception as exc:  # pragma: no cover - disk issues
+            logger.error("Failed to persist workflow state: %s", exc)
+        return state
+
+    def get_state(self, conversation_id: str) -> Dict[str, Any]:
+        """Return stored state for a conversation."""
+        return self._states.get(conversation_id, {})

--- a/py_consumer/providers/__init__.py
+++ b/py_consumer/providers/__init__.py
@@ -1,0 +1,7 @@
+
+"""Provider package exposing available AI providers."""
+
+from .openai_provider import OpenAIProvider
+from .deepseek_provider import DeepSeekProvider
+
+__all__ = ["OpenAIProvider", "DeepSeekProvider"]

--- a/py_consumer/providers/deepseek_provider.py
+++ b/py_consumer/providers/deepseek_provider.py
@@ -1,0 +1,79 @@
+"""DeepSeek provider implementation for the Python consumer."""
+
+from __future__ import annotations
+
+import logging
+from time import perf_counter
+from typing import Dict, Any, List
+
+try:
+    import aiohttp
+except Exception:  # pragma: no cover - optional dependency
+    aiohttp = None
+
+
+class DeepSeekProvider:
+    """Interface to the DeepSeek chat completion API."""
+
+    def __init__(self, config) -> None:
+        self.config = config
+        self.logger = logging.getLogger(__name__)
+        self.initialized = False
+        self.api_key = None
+        self.model = None
+
+    async def initialize(self) -> None:
+        if self.initialized:
+            return
+        self.api_key = self.config.get('ai_providers.deepseek.api_key')
+        self.model = self.config.get('ai_providers.deepseek.model', 'deepseek-chat')
+        self.initialized = True
+        self.logger.info("DeepSeek provider initialized")
+
+    async def generate_response(self, prompt_data: Dict[str, Any]) -> Dict[str, Any]:
+        if not self.initialized:
+            await self.initialize()
+
+        messages: List[Dict[str, str]] = prompt_data.get('messages', [])
+        if not messages and 'message' in prompt_data:
+            messages = [{'role': 'user', 'content': prompt_data['message']}]
+
+        if aiohttp is None:
+            text = " ".join(m['content'] for m in messages)
+            return {
+                'content': f"DeepSeek response to: {text}",
+                'tokens_used': len(text.split()),
+                'processing_time': 0.0,
+            }
+
+        headers = {
+            'Authorization': f'Bearer {self.api_key}',
+            'Content-Type': 'application/json',
+        }
+        payload = {
+            'model': self.model,
+            'messages': messages,
+            'max_tokens': self.config.get('ai_providers.deepseek.max_tokens', 2000),
+            'temperature': self.config.get('ai_providers.deepseek.temperature', 0.7),
+            'stream': False,
+        }
+
+        start = perf_counter()
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post('https://api.deepseek.com/v1/chat/completions', json=payload, headers=headers) as resp:
+                    data = await resp.json()
+            elapsed = perf_counter() - start
+            content = data['choices'][0]['message']['content']
+            tokens_used = data.get('usage', {}).get('total_tokens', 0)
+            return {
+                'content': content,
+                'tokens_used': tokens_used,
+                'processing_time': elapsed,
+            }
+        except Exception as exc:  # pragma: no cover - external dependency
+            self.logger.error("DeepSeek API error: %s", exc)
+            raise
+
+    async def health_check(self) -> Dict[str, Any]:
+        return {'healthy': bool(self.api_key)}

--- a/py_consumer/providers/openai_provider.py
+++ b/py_consumer/providers/openai_provider.py
@@ -1,0 +1,76 @@
+"""OpenAI provider implementation used by the Python consumer service."""
+
+from __future__ import annotations
+
+import logging
+from time import perf_counter
+from typing import Dict, Any, List
+
+try:  # OpenAI SDK may not be installed in minimal environments
+    import openai
+except Exception:  # pragma: no cover - optional dependency
+    openai = None
+
+
+class OpenAIProvider:
+    """Wrapper around the OpenAI chat completion API."""
+
+    def __init__(self, config) -> None:
+        self.config = config
+        self.logger = logging.getLogger(__name__)
+        self.initialized = False
+        self.api_key = None
+        self.model = None
+
+    async def initialize(self) -> None:
+        """Initialize provider configuration."""
+        if self.initialized:
+            return
+        self.api_key = self.config.get('ai_providers.openai.api_key')
+        self.model = self.config.get('ai_providers.openai.model', 'gpt-4-turbo-preview')
+        if openai is not None:
+            openai.api_key = self.api_key
+        self.initialized = True
+        self.logger.info("OpenAI provider initialized")
+
+    async def generate_response(self, prompt_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Generate a response using the OpenAI API."""
+        if not self.initialized:
+            await self.initialize()
+
+        messages: List[Dict[str, str]] = prompt_data.get('messages', [])
+        if not messages and 'message' in prompt_data:
+            messages = [{'role': 'user', 'content': prompt_data['message']}]
+
+        if openai is None:
+            # Fallback deterministic response if the SDK is unavailable
+            text = " ".join(m['content'] for m in messages)
+            return {
+                'content': f"OpenAI response to: {text}",
+                'tokens_used': len(text.split()),
+                'processing_time': 0.0,
+            }
+
+        start = perf_counter()
+        try:
+            response = await openai.ChatCompletion.acreate(
+                model=self.model,
+                messages=messages,
+                max_tokens=self.config.get('ai_providers.openai.max_tokens', 2000),
+                temperature=self.config.get('ai_providers.openai.temperature', 0.7),
+            )
+            elapsed = perf_counter() - start
+            content = response.choices[0].message.content
+            tokens_used = response.usage.total_tokens
+            return {
+                'content': content,
+                'tokens_used': tokens_used,
+                'processing_time': elapsed,
+            }
+        except Exception as exc:  # pragma: no cover - external dependency
+            self.logger.error("OpenAI API error: %s", exc)
+            raise
+
+    async def health_check(self) -> Dict[str, Any]:
+        """Return basic health information."""
+        return {'healthy': bool(self.api_key)}


### PR DESCRIPTION
## Summary
- add missing workflow_engine module to py_consumer so imports succeed
- add minimal slot extraction and prompt engine
- stub DeepSeek and OpenAI provider classes
- add simple in-memory config/api key routes and workflow phase list
- improve Python consumer features

## Testing
- `npm test` *(fails: jest not found)*
- `python -m pytest` *(fails: websockets missing)*

------
https://chatgpt.com/codex/tasks/task_e_687057ee63208329b1d8f7939f159005